### PR TITLE
Update platform.h to assert Mac recognition.

### DIFF
--- a/include/xbee/platform.h
+++ b/include/xbee/platform.h
@@ -306,7 +306,7 @@
 	#include XBEE_PLATFORM_HEADER
 #elif defined __DC__
 	#include "xbee/platform_rabbit.h"
-#elif defined POSIX
+#elif defined POSIX || defined __APPLE__
 	#include "xbee/platform_posix.h"
 #elif defined __DOS__
 	// Note: at present, only Open Watcom compiler supported


### PR DESCRIPTION
POSIX is not defined by my compiler, **APPLE** is. This is on GCC 4.8.3 installed from Homebrew. Compiler skips to the error on :322 and no platform_*.h is included, leading to errors during compilation.
