### PR TITLE
Fix implicit declaration of function strtoul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,14 @@ samples/posix/install_ebl
 samples/posix/transparent_client
 samples/posix/walker
 samples/posix/zcltime
+samples/posix/apply_profile
+samples/posix/eblinfo
+samples/posix/gpm
+samples/posix/ipv4_client
+samples/posix/network_scan
+samples/posix/sms_client
+samples/posix/xbee_term
+samples/posix/zigbee_walker
 t_memcheck
 zdo_simple_desc_respond
 zdo_match_desc_request

--- a/samples/common/transparent_client.c
+++ b/samples/common/transparent_client.c
@@ -51,6 +51,7 @@
 #include <stdio.h>
 #include <stddef.h>
 #include <string.h>
+#include <stdlib.h>
 
 #include "xbee/atcmd.h"
 #include "xbee/byteorder.h"


### PR DESCRIPTION
Fix implicit declaration of function strtoul during compilation of samples by adding stdlib.h to the transparent_client.c source.