### PR TITLE
ports/win32: use CreateFileA() instead of CreateFile()

### DIFF
--- a/ports/win32/xbee_serial_win32.c
+++ b/ports/win32/xbee_serial_win32.c
@@ -295,7 +295,7 @@ int xbee_ser_open( xbee_serial_t *serial, uint32_t baudrate)
     else
     {
         snprintf( buffer, sizeof buffer, "\\\\.\\COM%u", serial->comport);
-        hCom = CreateFile( buffer, GENERIC_READ | GENERIC_WRITE,
+        hCom = CreateFileA( buffer, GENERIC_READ | GENERIC_WRITE,
             0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
         if (hCom == INVALID_HANDLE_VALUE)
         {


### PR DESCRIPTION
Addressing #31 by switching from ```CreateFile()``` macro to the base ```CreateFileA()``` method. Using the original ```CreateFile()``` macro may result in improper resolution to the unicode/wchar method ```CreateFileW``` if certain definitions are missing.