### PR TITLE
Minor build changes

### DIFF
--- a/ports/posix/xbee_readline.c
+++ b/ports/posix/xbee_readline.c
@@ -45,7 +45,7 @@ int kbhit()
     return FD_ISSET(STDIN_FILENO, &fds);
 }
 
-struct termios _ttystate_orig;
+static struct termios _ttystate_orig;
 void _restore_tty( void)
 {
     tcsetattr(STDIN_FILENO, TCSANOW, &_ttystate_orig);

--- a/samples/common/xbee_ftp.c
+++ b/samples/common/xbee_ftp.c
@@ -206,7 +206,8 @@ int process_file_open(xbee_dev_t *xbee,
     const xbee_payload_fs_file_open_resp_t FAR *response = payload;
 
     if (length != sizeof(*response)) {
-        printf("  (data size %u != %u)\n", length, sizeof(*response));
+        printf("  (data size %u != %u)\n", length,
+               (unsigned)sizeof(*response));
         return -EINVAL;
     }
 
@@ -296,7 +297,8 @@ void print_vol_stat(const void FAR *payload, uint16_t length)
     const xbee_payload_fs_volume_resp_t FAR *response = payload;
 
     if (length != sizeof(*response)) {
-        printf("  (data size %u != %u)\n", length, sizeof(*response));
+        printf("  (data size %u != %u)\n", length, 
+               (unsigned)sizeof(*response));
     } else {
         uint32_t bytes[3];
 

--- a/samples/posix/xbee_term_posix.c
+++ b/samples/posix/xbee_term_posix.c
@@ -23,7 +23,7 @@
 
 #include "../common/_xbee_term.h"
 
-struct termios _ttystate_orig;
+static struct termios _ttystate_orig;
 void xbee_term_console_restore( void)
 {
    xbee_term_set_color(SOURCE_UNKNOWN);


### PR DESCRIPTION
Fixes #37 and quiets a compiler warning with an explicit cast from `size_t` to `unsigned` for a `%u` format specifier.