### PR TITLE
Library updates for June 2024

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,8 @@ Headers:
 - `xbee/bl_gen3.h`: Support for the "Gen3 Bootloader" used by S3B, S6, S6B,
   XLR, Cellular, SX, SX868, and S8 hardware.
 
+- `xbee/ble.h`: Support for BLE feature frames on the XBee3 BLU.
+
 - `xbee/byteorder.h`: Byte-order-related functions used by multiple layers
   of the driver.
 

--- a/frame_types.md
+++ b/frame_types.md
@@ -32,6 +32,7 @@ files written to handle them.
 | 0x34 | BLE GAP Scan Request        | xbee/ble.h, xbee_ble.c
 | 0x3B | File System Request         | xbee/file_system.h, xbee_file_system.c
 | 0x3C | Remote File System Request  | xbee/file_system.h, xbee_file_system.c
+| 0x3D | GNSS start stop             | xbee/gnss.h, xbee_gnss.c
 | 0x40 | Socket Create               | xbee/socket.h, xbee_socket.c
 | 0x41 | Socket Option               | xbee/socket.h, xbee_socket.c
 | 0x42 | Socket Connect              | xbee/socket.h, xbee_socket.c
@@ -82,6 +83,9 @@ files written to handle them.
 | 0xBA | Device Response Status      | *n/a*
 | 0xBB | File System Response        | xbee/file_system.h, xbee_file_system.c
 | 0xBC | Remote File System Response | xbee/file_system.h, xbee_file_system.c
+| 0xBD | GNSS Start Stop Response    | xbee/gnss.h, xbee/gnss.c
+| 0xBE | GNSS Raw NMEA Response      | xbee/gnss.h, xbee/gnss.c
+| 0xBF | GNSS One Shot Response      | xbee/gnss.h, xbee/gnss.c
 | 0xC0 | Socket Create Response      | xbee/socket.h, xbee_socket.c
 | 0xC1 | Socket Option Response      | xbee/socket.h, xbee_socket.c
 | 0xC2 | Socket Connect Response     | xbee/socket.h, xbee_socket.c

--- a/frame_types.md
+++ b/frame_types.md
@@ -29,6 +29,7 @@ files written to handle them.
 | 0x2C | BLE Unlock Request          | *n/a*
 | 0x2D | User Data Relay Tx          | xbee/user_data.h, xbee_user_data.c
 | 0x2E | Secure Session Control      | xbee/secure_session.h, xbee_secure_session.c
+| 0x34 | BLE GAP Scan Request        | xbee/ble.h, xbee_ble.c
 | 0x3B | File System Request         | xbee/file_system.h, xbee_file_system.c
 | 0x3C | Remote File System Request  | xbee/file_system.h, xbee_file_system.c
 | 0x40 | Socket Create               | xbee/socket.h, xbee_socket.c
@@ -73,6 +74,9 @@ files written to handle them.
 | 0xAD | User Data Relay Rx          | xbee/user_data.h, xbee_user_data.c
 | 0xAE | Secure Session Response     | xbee/secure_session.h, xbee_secure_session.c
 | 0xB0 | IPv4 Receive                | xbee/ipv4.h, xbee_ipv4.c
+| 0xB4 | BLE Scan Legacy Response    | xbee/ble.h, xbee_ble.c
+| 0xB5 | BLE Scan Status             | xbee/ble.h, xbee_ble.c
+| 0xB7 | BLE Scan Extended Response  | xbee/ble.h, xbee_ble.c
 | 0xB8 | Send Data Response          | *n/a*
 | 0xB9 | Device Request              | *n/a*
 | 0xBA | Device Response Status      | *n/a*

--- a/include/xbee/ble.h
+++ b/include/xbee/ble.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (c) 2024 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 11001 Bren Road East, Minnetonka, MN 55343
+ * =======================================================================
+ */
+
+/**
+    @defgroup xbee_ble Frames: BLE (0x34, 0xB4, 0xB5 and 0xB7)
+    @ingroup xbee_frame
+    @{
+    @file xbee/ble.h
+
+    Because this framework dispatches received frames to frame handlers, this
+    API layer for BLE makes use of callbacks to pass advertisement responses
+    back to the calling code.
+
+    Calling code uses xbee_ble_scan_request() to initiate a scan. The caller
+    is expected to have receive handlers in the xbee_frame_handlers[] that
+    can handle the frame responses. See below for the callback descriptions
+    and definitions.
+
+    For use with the XBee BLU.
+*/
+
+#ifndef XBEE_BLE_H
+#define XBEE_BLE_H
+
+#include "xbee/platform.h"
+#include "xbee/device.h"
+#include "xbee/ble_frames.h"
+
+XBEE_BEGIN_DECLS
+
+/**
+    @brief
+    Callback handler for status updates from a scan request.
+
+    \a status contains one of the XBEE_BLE_SCAN_STATUS_xxx values:
+        - XBEE_FRAME_BLE_SCAN_STATUS_SUCCESS
+        - XBEE_FRAME_BLE_SCAN_STATUS_RUNNING
+        - XBEE_FRAME_BLE_SCAN_STATUS_STOPPED
+        - XBEE_FRAME_BLE_SCAN_STATUS_ERROR
+        - XBEE_FRAME_BLE_SCAN_STATUS_INVALID_PARAMS
+
+    @param[in]  frame_type  XBee frame responsible for the status update.
+    @param[in]  status      Status delivered. See above for possibilities.
+*/
+typedef void (*xbee_ble_scan_status_fn)(uint8_t frame_type,
+                                        uint8_t status);
+
+/**
+    @brief Initiate a scan request. A BLE Scan Status frame will be returned
+           when the scan request has been processed.
+
+    @param[in]  xbee            XBee device sending the message
+    @param[in]  scan_duration   Scan duration in seconds. Can be set to zero
+                                for an indefinite scan. Scans can be stopped
+                                early with xbee_ble_scan_stop().
+    @param[in]  scan_window     Scan window in microseconds. This parameter
+                                must not be bigger than scan duration.
+    @param[in]  scan_interval   Scan interval in microseconds. This parameter
+                                must not be bigger than the scan window.
+    @param[in]  filter_type     Bitfield where only one option may be selected:
+                                - XBEE_BLE_SCAN_FILTER_NAME
+    @param[in]  filter          Filter data, its form being dictated by
+                                /a filter_type. The data passed, even if it is
+                                a string, does not need to be null-terminated.
+    @param[in]  filter_length   Length of the /a filter parameter in bytes.
+
+    @retval  0                  Successfully queued the request frame.
+    @retval  -EINVAL            Invalid parameter passed to function.
+    @retval  -E2BIG             The /a filter_length is invalid given the
+                                /a filter_type.
+
+    @sa xbee_ble_scan_stop()
+*/
+int xbee_ble_scan_start(xbee_dev_t *xbee, uint16_t scan_duration,
+                        uint32_t scan_window, uint32_t scan_interval,
+                        uint8_t filter_type, const uint8_t *filter,
+                        size_t filter_len);
+
+/**
+    @brief Stop an in-progress scan. A BLE Scan Status frame will be returned
+           when the scan request has been processed.
+
+    @param[in]  xbee            XBee device sending the message
+
+    @retval  0                  Successfully queued the request frame.
+    @retval  -EINVAL            Invalid parameter passed to function.
+
+    @sa xbee_ble_scan_start()
+*/
+int xbee_ble_scan_stop(xbee_dev_t *xbee);
+
+/**
+    @brief Dump received BLE scan status  message to stdout.
+
+    This is a sample frame handler that simply prints received BLE messages
+    to the screen.  Include it in your frame handler table as:
+
+    { XBEE_FRAME_BLE_SCAN_STATUS, 0, xbee_ble_scan_status_dump, NULL }
+
+    See the function help for xbee_frame_handler_fn() for full
+    documentation on this function's API.
+*/
+int xbee_ble_scan_status_dump(xbee_dev_t *xbee, const void FAR *raw,
+                              uint16_t length, void FAR *context);
+
+/**
+    @brief Dump received BLE legacy advertisement message to stdout.
+
+    This is a sample frame handler that simply prints received BLE messages
+    to the screen.  Include it in your frame handler table as:
+
+    { XBEE_FRAME_BLE_SCAN_LEGACY_ADVERT_RESP, 0, xbee_ble_scan_legacy_advert_dump, NULL }
+
+    See the function help for xbee_frame_handler_fn() for full
+    documentation on this function's API.
+*/
+int xbee_ble_scan_legacy_advert_dump(xbee_dev_t *xbee, const void FAR *raw,
+                                     uint16_t length, void FAR *context);
+
+/**
+    @brief Dump received BLE extended advertisement message to stdout.
+
+    This is a sample frame handler that simply prints received BLE messages
+    to the screen.  Include it in your frame handler table as:
+
+    { XBEE_FRAME_BLE_SCAN_EXT_ADVERT_RESP, 0, xbee_ble_scan_ext_advert_dump, NULL }
+
+    See the function help for xbee_frame_handler_fn() for full
+    documentation on this function's API.
+*/
+int xbee_ble_scan_ext_advert_dump(xbee_dev_t *xbee, const void FAR *raw,
+                                  uint16_t length, void FAR *context);
+
+XBEE_END_DECLS
+
+#endif // XBEE_BLE_H
+
+///@}

--- a/include/xbee/ble.h
+++ b/include/xbee/ble.h
@@ -25,7 +25,7 @@
     can handle the frame responses. See below for the callback descriptions
     and definitions.
 
-    For use with the XBee BLU.
+    For use with the XBee 3 BLU.
 */
 
 #ifndef XBEE_BLE_H
@@ -82,7 +82,7 @@ typedef void (*xbee_ble_scan_status_fn)(uint8_t frame_type,
 */
 int xbee_ble_scan_start(xbee_dev_t *xbee, uint16_t scan_duration,
                         uint32_t scan_window, uint32_t scan_interval,
-                        uint8_t filter_type, const uint8_t *filter,
+                        uint8_t filter_type, const void *filter,
                         size_t filter_len);
 
 /**

--- a/include/xbee/ble_frames.h
+++ b/include/xbee/ble_frames.h
@@ -1,0 +1,120 @@
+/*
+ * Copyright (c) 2024 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc., 9350 Excelsior Blvd., Suite 700, Hopkins, MN 55343
+ * ===========================================================================
+ */
+
+/**
+    @addtogroup xbee_ble
+    @{
+    @file xbee/ble_frames.h
+
+    Frame definitions and support functions for BLE frames
+    (0x34, 0xB4, 0xB5 and 0xB7).
+
+    For use with the XBee BLU
+*/
+
+#ifndef XBEE_BLE_FRAMES_H
+#define XBEE_BLE_FRAMES_H
+
+#include "xbee/platform.h"
+
+XBEE_BEGIN_DECLS
+
+/// Flag used in advertisement responses, in the 0xB4 and 0xB7 frame types
+#define XBEE_BLE_ADVERT_FLAG_CONNECTABLE  ( 1 << 0 ) // Advertisement is connectable
+
+// Max and min values for the scan window and the scan interval in microseconds.
+#define XBEE_BLE_SCAN_VALUES_MAX_USEC       (0x270FD8F)
+#define XBEE_BLE_SCAN_VALUES_MIN_USEC       (0x9C4)
+
+/// Frame Type: BLE Scan Request
+#define XBEE_FRAME_BLE_SCAN_REQUEST             0x34
+/// Format of the XBee API frame type 0x34 (#XBEE_FRAME_BLE_SCAN_REQUEST)
+/// Sent from host to XBee, which responds with XBEE_FRAME_BLE_SCAN_STATUS
+typedef XBEE_PACKED(xbee_frame_ble_scan_req_t, {
+    uint8_t    frame_type;          ///< XBEE_FRAME_BLE_SCAN_REQUEST (0x34)
+    uint8_t    start_cmd;           ///< start/stop command, start=1 & stop=0
+    uint16_t   scan_duration_be;    ///< scan duration in seconds
+    uint32_t   scan_window_be;      ///< scanning window in microseconds
+    uint32_t   scan_interval_be;    ///< scanning interval in microseconds
+    uint8_t    filter_type;         ///< type of filters to apply to scan
+#define XBEE_BLE_SCAN_FILTER_NONE         ( 0 )
+#define XBEE_BLE_SCAN_FILTER_NAME         ( 1 << 0 )   // Filter on local name. 
+    uint8_t    filter[1];           ///< filter value, max 22 bytes
+}) xbee_frame_ble_scan_req_t;
+
+typedef XBEE_PACKED(xbee_header_ble_scan_req_t, {
+    uint8_t    frame_type;          ///< XBEE_FRAME_BLE_SCAN_REQUEST (0x34)
+    uint8_t    start_cmd;           ///< start/stop command, start=1 & stop=0
+    uint16_t   scan_duration_be;    ///< scan duration in seconds
+    uint32_t   scan_window_be;      ///< scanning window in microseconds
+    uint32_t   scan_interval_be;    ///< scanning interval in microseconds
+    uint8_t    filter_type;         ///< type of filters to apply to scan
+}) xbee_header_ble_scan_req_t;
+
+/// Frame Type: BLE Scan Status
+#define XBEE_FRAME_BLE_SCAN_STATUS              0xB5
+/// Format of the XBee API frame type 0xB5 (#XBEE_FRAME_BLE_SCAN_STATUS)
+/// Sent from XBee to host.
+typedef XBEE_PACKED(xbee_frame_ble_scan_status_t, {
+    uint8_t    frame_type;         ///< XBEE_FRAME_BLE_SCAN_STATUS (0xB5)
+    uint8_t    scan_status;        ///< request status
+#define XBEE_BLE_SCAN_STATUS_SUCCESS            0x00
+#define XBEE_BLE_SCAN_STATUS_RUNNING            0x01
+#define XBEE_BLE_SCAN_STATUS_STOPPED            0x02
+#define XBEE_BLE_SCAN_STATUS_ERROR              0x03
+#define XBEE_BLE_SCAN_STATUS_INVALID_PARAMS     0x04
+}) xbee_frame_ble_scan_status_t;
+
+/// Frame Type: BLE Scan Legacy Advertisement Response
+#define XBEE_FRAME_BLE_SCAN_LEGACY_ADVERT_RESP  0xB4
+/// Sent from XBee to host. Sent out when an advertisement is found.
+typedef XBEE_PACKED(xbee_frame_ble_scan_legacy_advert_resp_t, {
+    uint8_t    frame_type;         ///< XBEE_FRAME_BLE_SCAN_LEGACY_ADVERT_RESP (0xB4)
+    uint8_t    address[6];         ///< BLE MAC address of received advertisment
+    uint8_t    address_type;       ///< indicates the address type, public or random
+    uint8_t    advert_flags;       ///< advertisement flags
+    int8_t     rssi;               ///< receieve signal strength, in dBm
+    uint8_t    reserved;           ///< reserved for future use
+    uint8_t    payload_len;        ///< length of the advertisement payload
+    uint8_t    payload[1];         ///< payload of the advertisement
+}) xbee_frame_ble_scan_legacy_advert_resp_t;
+
+/// Frame Type: BLE Scan Extended Advertisement Response
+#define XBEE_FRAME_BLE_SCAN_EXT_ADVERT_RESP     0xB7
+/// Sent from XBee to host. Sent out when an advertisement is found.
+typedef XBEE_PACKED(xbee_frame_ble_scan_ext_advert_resp_t, {
+    uint8_t    frame_type;              ///< XBEE_FRAME_BLE_SCAN_EXT_ADVERT_RESP (0xB7)
+    uint8_t    address[6];              ///< BLE MAC address of received advertisment
+    uint8_t    address_type;            ///< indicates the address type, public or random
+    uint8_t    advert_flags;            ///< advertisement flags
+    int8_t     rssi;                    ///< receieve signal strength, in dBm
+    uint8_t    reserved;                ///< reserved for future use
+    uint8_t    advert_ident;            ///< advertisement set idenitifier
+    uint8_t    primary_phy;             ///< primary PHY, used for a connection
+    uint8_t    secondary_phy;           ///< secondary PHY, used for a connection
+#define XBEE_BLE_PHY_FLAG_1M    ( 1 << 0 )
+#define XBEE_BLE_PHY_FLAG_2M    ( 1 << 1 )
+#define XBEE_BLE_PHY_FLAG_125K  ( 1 << 2 )
+#define XBEE_BLE_PHY_FLAG_500K  ( 1 << 3 )
+#define XBEE_BLE_PHY_FLAG_ALL   ( 0xFF )
+    uint8_t    tx_power;                ///< transmission power of received advert
+    uint16_t   periodic_interval_be;    ///< interval for periodic advertising
+    uint8_t    data_complete;           ///< data completion flags
+    uint8_t    payload_len;             ///< length of the advertisement payload
+    uint8_t    payload[1];              ///< payload of the advertisement
+}) xbee_frame_ble_scan_ext_advert_resp_t;
+
+XBEE_END_DECLS
+
+#endif // XBEE_BLE_FRAMES_H
+
+///@}

--- a/include/xbee/ble_frames.h
+++ b/include/xbee/ble_frames.h
@@ -18,7 +18,7 @@
     Frame definitions and support functions for BLE frames
     (0x34, 0xB4, 0xB5 and 0xB7).
 
-    For use with the XBee BLU
+    For use with the XBee 3 BLU
 */
 
 #ifndef XBEE_BLE_FRAMES_H
@@ -28,12 +28,15 @@
 
 XBEE_BEGIN_DECLS
 
+#define XBEE_BLE_ADDRESS_TYPE_PUBLIC (0)
+#define XBEE_BLE_ADDRESS_TYPE_RANDOM (1)
+
 /// Flag used in advertisement responses, in the 0xB4 and 0xB7 frame types
 #define XBEE_BLE_ADVERT_FLAG_CONNECTABLE  ( 1 << 0 ) // Advertisement is connectable
 
 // Max and min values for the scan window and the scan interval in microseconds.
-#define XBEE_BLE_SCAN_VALUES_MAX_USEC       (0x270FD8F)
-#define XBEE_BLE_SCAN_VALUES_MIN_USEC       (0x9C4)
+#define XBEE_BLE_SCAN_VALUES_MAX_USEC       (0xFFFF * 625)
+#define XBEE_BLE_SCAN_VALUES_MIN_USEC       (2500)
 
 /// Frame Type: BLE Scan Request
 #define XBEE_FRAME_BLE_SCAN_REQUEST             0x34
@@ -80,9 +83,9 @@ typedef XBEE_PACKED(xbee_frame_ble_scan_status_t, {
 typedef XBEE_PACKED(xbee_frame_ble_scan_legacy_advert_resp_t, {
     uint8_t    frame_type;         ///< XBEE_FRAME_BLE_SCAN_LEGACY_ADVERT_RESP (0xB4)
     uint8_t    address[6];         ///< BLE MAC address of received advertisment
-    uint8_t    address_type;       ///< indicates the address type, public or random
-    uint8_t    advert_flags;       ///< advertisement flags
-    int8_t     rssi;               ///< receieve signal strength, in dBm
+    uint8_t    address_type;       ///< indicates the address type (XBEE_BLE_ADDRESS_TYPE_xxx)
+    uint8_t    advert_flags;       ///< advertisement flags (XBEE_BLE_ADVERT_FLAG_xxx)
+    int8_t     rssi;               ///< receive signal strength, in dBm
     uint8_t    reserved;           ///< reserved for future use
     uint8_t    payload_len;        ///< length of the advertisement payload
     uint8_t    payload[1];         ///< payload of the advertisement
@@ -106,7 +109,7 @@ typedef XBEE_PACKED(xbee_frame_ble_scan_ext_advert_resp_t, {
 #define XBEE_BLE_PHY_FLAG_125K  ( 1 << 2 )
 #define XBEE_BLE_PHY_FLAG_500K  ( 1 << 3 )
 #define XBEE_BLE_PHY_FLAG_ALL   ( 0xFF )
-    uint8_t    tx_power;                ///< transmission power of received advert
+    int8_t     tx_power;                ///< transmission power of received advert, in dBm
     uint16_t   periodic_interval_be;    ///< interval for periodic advertising
     uint8_t    data_complete;           ///< data completion flags
     uint8_t    payload_len;             ///< length of the advertisement payload

--- a/include/xbee/device.h
+++ b/include/xbee/device.h
@@ -381,23 +381,32 @@ typedef struct xbee_dev_t
       Macros related to the \c hardware_version field of xbee_dev_t.
       @{
    */
-      #define XBEE_HARDWARE_MASK          0xFF00
-      #define XBEE_HARDWARE_S1            0x1700
-      #define XBEE_HARDWARE_S1_PRO        0x1800
-      #define XBEE_HARDWARE_S2            0x1900
-      #define XBEE_HARDWARE_S2_PRO        0x1A00
-      #define XBEE_HARDWARE_900_PRO       0x1B00
-      #define XBEE_HARDWARE_868_PRO       0x1D00
-      #define XBEE_HARDWARE_S2B_PRO       0x1E00
-      #define XBEE_HARDWARE_S2C_PRO       0x2100
-      #define XBEE_HARDWARE_S2C           0x2200
-      #define XBEE_HARDWARE_S3B           0x2300      // XBee 900HP
-      #define XBEE_HARDWARE_S8            0x2400
-      #define XBEE_HARDWARE_S6B           0x2700      // XBee Wi-Fi
-      #define XBEE_HARDWARE_CELL_CAT1_VZW 0x4000
-      #define XBEE_HARDWARE_XB3_MICRO     0x4100
-      #define XBEE_HARDWARE_XB3_TH        0x4200
-      #define XBEE_HARDWARE_CELL_3G       0x4400
+      #define XBEE_HARDWARE_MASK                0xFF00
+      #define XBEE_HARDWARE_S1                  0x1700
+      #define XBEE_HARDWARE_S1_PRO              0x1800
+      #define XBEE_HARDWARE_S2                  0x1900
+      #define XBEE_HARDWARE_S2_PRO              0x1A00
+      #define XBEE_HARDWARE_900_PRO             0x1B00
+      #define XBEE_HARDWARE_868_PRO             0x1D00
+      #define XBEE_HARDWARE_S2B_PRO             0x1E00
+      #define XBEE_HARDWARE_S2C_PRO             0x2100
+      #define XBEE_HARDWARE_S2C                 0x2200
+      #define XBEE_HARDWARE_S3B                 0x2300      // XBee 900HP
+      #define XBEE_HARDWARE_S8                  0x2400
+      #define XBEE_HARDWARE_S6B                 0x2700      // XBee Wi-Fi
+      #define XBEE_HARDWARE_CELL_CAT1_VZW       0x4000
+      #define XBEE_HARDWARE_XB3_MICRO           0x4100
+      #define XBEE_HARDWARE_XB3_TH              0x4200
+      #define XBEE_HARDWARE_CELL_3G             0x4400
+      #define XBEE3_HARDWARE_CELL_CAT1_ATT      0x4900
+      #define XBEE3_HARDWARE_CELL_LTEM_ATT      0x4B00
+      #define XBEE3_HARDWARE_CELL_CAT1_VZW      0x4D00
+      #define XBEE3_HARDWARE_CELL_LTEM_GLOBAL   0x4E00
+      #define XBEE3_HARDWARE_CELL_CAT1_GLOBAL   0x5400
+      #define XBEE3_HARDWARE_CELL_CAT1_NA       0x5500
+      #define XBEE3_HARDWARE_CELL_LTEM_LP       0x5600
+      #define XBEE3_HARDWARE_CELL_BLU_SMT       0x5C00
+      #define XBEE3_HARDWARE_CELL_BLU_TH        0x5D00
    ///@}
 
    /// Value of XBee module's HS register.

--- a/include/xbee/device.h
+++ b/include/xbee/device.h
@@ -402,11 +402,18 @@ typedef struct xbee_dev_t
       #define XBEE3_HARDWARE_CELL_LTEM_ATT      0x4B00
       #define XBEE3_HARDWARE_CELL_CAT1_VZW      0x4D00
       #define XBEE3_HARDWARE_CELL_LTEM_GLOBAL   0x4E00
+      #define XBEE_HARDWARE_XR_900              0x5000
+      #define XBEE_HARDWARE_XR_686              0x5100
+      #define XBEE_HARDWARE_RR                  0x5200
       #define XBEE3_HARDWARE_CELL_CAT1_GLOBAL   0x5400
       #define XBEE3_HARDWARE_CELL_CAT1_NA       0x5500
       #define XBEE3_HARDWARE_CELL_LTEM_LP       0x5600
-      #define XBEE3_HARDWARE_CELL_BLU_SMT       0x5C00
-      #define XBEE3_HARDWARE_CELL_BLU_TH        0x5D00
+      #define XBEE_HARDWARE_RR_TH               0x5700
+      #define XBEE_HARDWARE_XR_900_TH           0x5A00
+      #define XBEE_HARDWARE_XR_686_TH           0x5B00
+      #define XBEE3_HARDWARE_BLU_SMT            0x5C00
+      #define XBEE3_HARDWARE_BLU_TH             0x5D00
+      #define XBEE_HARWARE_LORA                 0x5E00
    ///@}
 
    /// Value of XBee module's HS register.

--- a/include/xbee/gnss.h
+++ b/include/xbee/gnss.h
@@ -1,0 +1,161 @@
+/*
+ * Copyright (c) 2024 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc., 9350 Excelsior Blvd., Suite 700, Hopkins, MN 55343
+ * ===========================================================================
+ */
+
+/**
+    @addtogroup xbee_gnss
+    @{
+    @file xbee/gnss_frames.h
+
+    Frame definitions and support functions for GNSS frames
+    (0x3D and 0xBD-0xBF).  For use with XBee Cellular devices that support
+    GNSS.
+*/
+
+#ifndef XBEE_GNSS_H
+#define XBEE_GNSS_H
+
+#include "xbee/platform.h"
+#include "xbee/device.h"
+
+#if !XBEE_CELLULAR_ENABLED
+   #error "XBEE_CELLULAR_ENABLED must be defined as non-zero " \
+      "to use this header."
+#endif
+
+XBEE_BEGIN_DECLS
+
+// GNSS frame types
+#define XBEE_FRAME_GNSS_START_STOP 0x3D
+#define XBEE_FRAME_GNSS_START_STOP_RESP 0xBD
+#define XBEE_FRAME_GNSS_RAW_NMEA_RESP 0xBE
+#define XBEE_FRAME_GNSS_ONE_SHOT_RESP 0xBF
+
+/// Format of XBee API frame type 0x3D (#XBEE_FRAME_GNSS_START_STOP).
+/// Sent from host to XBee, which responds with XBEE_FRAME_START_STOP_RESP.
+typedef XBEE_PACKED(xbee_frame_gnss_start_stop_t, {
+    uint8_t     frame_type;     ///< XBEE_FRAME_GNSS_START_STOP (0x3D)
+    uint8_t     frame_id;       ///< identifier to match response frame
+    uint8_t     type;
+#define XBEE_GNSS_START_ONE_SHOT          0       ///< Start one shot
+#define XBEE_GNSS_STOP_ONE_SHOT          4       ///< Stop one shot
+#define XBEE_GNSS_START_RAW_NMEA          5       ///< Start RAW NMEA
+#define XBEE_GNSS_STOP_RAW_NMEA          6       ///< Stop RAW NMEA
+    uint16_t    timeout;       ///< timeout in seconds for one shot only, a value of 0 is return cached value
+}) xbee_frame_gnss_start_stop_t;
+
+
+
+/// Format of XBee API frame type 0xBD (#XBEE_FRAME_GNSS_START_STOP_RESP).
+/// Sent from XBee to host
+typedef XBEE_PACKED(xbee_frame_gnss_start_stop_resp_t, {
+    uint8_t     frame_type;     ///< XBEE_FRAME_GNSS_START_STOP_RESP (0xBD)
+    uint8_t     frame_id;       ///< identifier to match response frame
+    uint8_t     type;          ///< matches type of the request frame
+    uint8_t     status;        ///<
+#define GNSS_START_STOP_STATUS_SUCCESS     0
+#define GNSS_START_STOP_STATUS_UNSUCCESSFUL 1
+}) xbee_frame_gnss_start_stop_resp_t;
+
+
+/// Format of XBee API frame type 0xBE (#XBEE_FRAME_GNSS_RAW_NMEA_RESP).
+/// Sent from XBee to host
+typedef XBEE_PACKED(xbee_frame_gnss_raw_nmea_resp_t, {
+    uint8_t     frame_type;     ///< XBEE_FRAME_GNSS_RAW_NMEA_RESP (0xBE)
+    uint8_t     frame_id;       ///< identifier to match response frame
+    uint8_t     payload[1];     ///< variable-length payload
+}) xbee_frame_gnss_raw_nmea_resp_t;
+
+
+
+/// Format of XBee API frame type 0xBF (#XBEE_FRAME_GNSS_ONE_SHOT_RESP).
+/// Sent from XBee to host
+typedef XBEE_PACKED(xbee_frame_gnss_one_shot_resp_t, {
+    uint8_t     frame_type;     ///< XBEE_FRAME_GNSS_ONE_SHOT_RESP (0xBF)
+    uint8_t     status;         ///<
+#define XBEE_GNSS_ONE_SHOT_STATUS_VALID       0
+#define XBEE_GNSS_ONE_SHOT_STATUS_INVALID     1
+#define XBEE_GNSS_ONE_SHOT_STATUS_TIMEOUT     2
+#define XBEE_GNSS_ONE_SHOT_STATUS_CANCELED    3
+    uint32_t    lock_time;      ///< Lock time measured in seconds, from midnight, Jan-1-2000
+    uint32_t    latitude;       ///< Latitude in decimal degrees, multiplied by 10 million.  Positive values are north of the equator.  Negative values are south of the equator.
+    uint32_t    longitude;      ///< Longitude in decimal degrees, multiplied by 10 million.  Positive values are east of the prime meridian.  Negative values are west of the prime meridian.
+    uint32_t    altitude;       ///< Altitude in millimeters
+    uint8_t     satellites;     ///< Total number of satellites in use.
+}) xbee_frame_gnss_one_shot_resp_t;
+
+
+// XBEE_GNSS_START_STOP_OPT_xxx values.
+#define XBEE_GNSS_START_STOP_OPT_NO_RESP    0x0001   // Don't send a response frame
+
+
+/**
+   @brief Start a GNSS one shot request.
+
+   @param[in]  xbee     XBee device sending the message
+   @param[in]  timeout  The timeout in seconds to wait for GNSS location data.  A value of 0 is return cached value.
+   @param[in]  options  Bitmask of frame options.
+                  XBEE_GNSS_START_STOP_OPT_NO_RESP - don't send a response frame
+
+   @retval  0           Message sent with XBEE_GNSS_START_STOP_OPT_NO_RESP.
+   @retval  >0          Frame ID of message, to correlate with the response
+                        frame received from XBee module.
+   @retval  -EINVAL     Invalid parameter passed to function.
+*/
+int xbee_gnss_start_one_shot(xbee_dev_t *xbee, uint16_t timeout, uint16_t options);
+
+
+/**
+   @brief Stop a GNSS one shot request.
+
+   @param[in]  xbee     XBee device sending the message
+   @param[in]  options  Bitmask of frame options.
+                  XBEE_GNSS_START_STOP_OPT_NO_RESP - don't send a response frame
+
+   @retval  0           Message sent with XBEE_GNSS_START_STOP_OPT_NO_RESP.
+   @retval  >0          Frame ID of message, to correlate with the response
+                        frame received from XBee module.
+   @retval  -EINVAL     Invalid parameter passed to function.
+*/
+int xbee_gnss_stop_one_shot(xbee_dev_t *xbee, uint16_t options);
+
+/**
+   @brief Start a GNSS NMEA stream.
+
+   @param[in]  xbee     XBee device sending the message
+   @param[in]  options  Bitmask of frame options.
+                  XBEE_GNSS_START_STOP_OPT_NO_RESP - don't send a response frame
+
+   @retval  0           Message sent with XBEE_GNSS_START_STOP_OPT_NO_RESP.
+   @retval  >0          Frame ID of message, to correlate with the response
+                        frame received from XBee module.
+   @retval  -EINVAL     Invalid parameter passed to function.
+*/
+int xbee_gnss_start_raw_nmea(xbee_dev_t *xbee, uint16_t options);
+
+/**
+   @brief Stop a GNSS NMEA stream.
+
+   @param[in]  xbee     XBee device sending the message
+   @param[in]  options  Bitmask of frame options.
+                XBEE_GNSS_START_STOP_OPT_NO_RESP - don't send a response frame
+
+   @retval  0           Message sent with XBEE_GNSS_START_STOP_OPT_NO_RESP.
+   @retval  >0          Frame ID of message, to correlate with the response
+                        frame received from XBee module.
+   @retval  -EINVAL     Invalid parameter passed to function.
+*/
+int xbee_gnss_stop_raw_nmea(xbee_dev_t *xbee, uint16_t options);
+
+
+XBEE_END_DECLS
+
+#endif // XBEE_GNSS_H

--- a/include/xbee/gnss.h
+++ b/include/xbee/gnss.h
@@ -17,7 +17,7 @@
 
     Frame definitions and support functions for GNSS frames
     (0x3D and 0xBD-0xBF).  For use with XBee Cellular devices that support
-    GNSS.
+    GNSS (Global Navigation Satellite System).
 */
 
 #ifndef XBEE_GNSS_H
@@ -44,12 +44,12 @@ XBEE_BEGIN_DECLS
 typedef XBEE_PACKED(xbee_frame_gnss_start_stop_t, {
     uint8_t     frame_type;     ///< XBEE_FRAME_GNSS_START_STOP (0x3D)
     uint8_t     frame_id;       ///< identifier to match response frame
-    uint8_t     type;
-#define XBEE_GNSS_START_ONE_SHOT          0       ///< Start one shot
-#define XBEE_GNSS_STOP_ONE_SHOT          4       ///< Stop one shot
-#define XBEE_GNSS_START_RAW_NMEA          5       ///< Start RAW NMEA
-#define XBEE_GNSS_STOP_RAW_NMEA          6       ///< Stop RAW NMEA
-    uint16_t    timeout;       ///< timeout in seconds for one shot only, a value of 0 is return cached value
+    uint8_t     request;
+#define XBEE_GNSS_REQUEST_START_ONE_SHOT          0       ///< Start one shot
+#define XBEE_GNSS_REQUEST_STOP_ONE_SHOT           4       ///< Stop one shot
+#define XBEE_GNSS_REQUEST_START_RAW_NMEA          5       ///< Start RAW NMEA 0183 output
+#define XBEE_GNSS_REQUEST_STOP_RAW_NMEA           6       ///< Stop RAW NMEA 0183 output
+    uint16_t    timeout_be;     ///< timeout in seconds for one shot only, a value of 0 is return cached value
 }) xbee_frame_gnss_start_stop_t;
 
 
@@ -59,10 +59,10 @@ typedef XBEE_PACKED(xbee_frame_gnss_start_stop_t, {
 typedef XBEE_PACKED(xbee_frame_gnss_start_stop_resp_t, {
     uint8_t     frame_type;     ///< XBEE_FRAME_GNSS_START_STOP_RESP (0xBD)
     uint8_t     frame_id;       ///< identifier to match response frame
-    uint8_t     type;          ///< matches type of the request frame
-    uint8_t     status;        ///<
-#define GNSS_START_STOP_STATUS_SUCCESS     0
-#define GNSS_START_STOP_STATUS_UNSUCCESSFUL 1
+    uint8_t     request;        ///< matches type of the request frame
+    uint8_t     status;         ///<
+#define XBEE_GNSS_START_STOP_STATUS_SUCCESS     0
+#define XBEE_GNSS_START_STOP_STATUS_UNSUCCESSFUL 1
 }) xbee_frame_gnss_start_stop_resp_t;
 
 
@@ -85,15 +85,16 @@ typedef XBEE_PACKED(xbee_frame_gnss_one_shot_resp_t, {
 #define XBEE_GNSS_ONE_SHOT_STATUS_INVALID     1
 #define XBEE_GNSS_ONE_SHOT_STATUS_TIMEOUT     2
 #define XBEE_GNSS_ONE_SHOT_STATUS_CANCELED    3
-    uint32_t    lock_time;      ///< Lock time measured in seconds, from midnight, Jan-1-2000
-    uint32_t    latitude;       ///< Latitude in decimal degrees, multiplied by 10 million.  Positive values are north of the equator.  Negative values are south of the equator.
-    uint32_t    longitude;      ///< Longitude in decimal degrees, multiplied by 10 million.  Positive values are east of the prime meridian.  Negative values are west of the prime meridian.
-    uint32_t    altitude;       ///< Altitude in millimeters
+    uint32_t    lock_time_be;   ///< Lock time measured in seconds, from midnight, Jan-1-2000
+    uint32_t    latitude_be;    ///< Latitude in decimal degrees * 1e7 (+/-9000000000 for +/-90.0). Positive/negative values are north/south of the equator.
+    uint32_t    longitude_be;   ///< Longitude in decimal degrees * 1e7 (+/-1800000000 for +/-180.0). Positive/negative values are east/west of the prime meridian.
+    uint32_t    altitude_be;    ///< Altitude in millimeters
     uint8_t     satellites;     ///< Total number of satellites in use.
 }) xbee_frame_gnss_one_shot_resp_t;
 
 
 // XBEE_GNSS_START_STOP_OPT_xxx values.
+#define XBEE_GNSS_START_STOP_OPT_NONE       0x0000
 #define XBEE_GNSS_START_STOP_OPT_NO_RESP    0x0001   // Don't send a response frame
 
 
@@ -128,7 +129,7 @@ int xbee_gnss_start_one_shot(xbee_dev_t *xbee, uint16_t timeout, uint16_t option
 int xbee_gnss_stop_one_shot(xbee_dev_t *xbee, uint16_t options);
 
 /**
-   @brief Start a GNSS NMEA stream.
+   @brief Start a GNSS NMEA 0183 sentence output stream.
 
    @param[in]  xbee     XBee device sending the message
    @param[in]  options  Bitmask of frame options.
@@ -142,7 +143,7 @@ int xbee_gnss_stop_one_shot(xbee_dev_t *xbee, uint16_t options);
 int xbee_gnss_start_raw_nmea(xbee_dev_t *xbee, uint16_t options);
 
 /**
-   @brief Stop a GNSS NMEA stream.
+   @brief Stop a GNSS NMEA 0183 sentence output stream.
 
    @param[in]  xbee     XBee device sending the message
    @param[in]  options  Bitmask of frame options.

--- a/samples/README.md
+++ b/samples/README.md
@@ -107,6 +107,12 @@ collection of sample programs.
 
 ### Cellular Samples
 
+- **GNSS One Shot**
+  Demonstrates getting location for XBee devices that support GNSS.
+
+- **GNSS NMEA**:
+  Demonstrates streaming NMEA for XBee devices that support GNSS.
+
 - **IPv4 Client**:
   Demonstrates communication via TCP over IPv4 frames.
 

--- a/samples/README.md
+++ b/samples/README.md
@@ -39,8 +39,8 @@ with platform-specific support code in each `samples/<target>` directory.
 
 - **Network Scan**:
   Perform an `ATAS` "active scan" and report the results.  Intended for
-  Zigbee and Wi-Fi networks, but could work for others after updating
-  `src/xbee/xbee_scan.c` for new scan types.
+  Zigbee, Wi-Fi and Cellular networks, but could work for others after
+  updating `src/xbee/xbee_scan.c` for new scan types.
 
 - **Transparent Client**:
   Demonstrate the "transparent serial" cluster used by XBee modules in

--- a/samples/README.md
+++ b/samples/README.md
@@ -108,10 +108,12 @@ collection of sample programs.
 ### Cellular Samples
 
 - **GNSS One Shot**
-  Demonstrates getting location for XBee devices that support GNSS.
+  Demonstrates getting location for XBee devices that support GNSS
+  (Global Navigation Satellite System).
 
 - **GNSS NMEA**:
-  Demonstrates streaming NMEA for XBee devices that support GNSS.
+  Demonstrates streaming NMEA 0183 messages for XBee devices that support GNSS
+  (Global Navigation Satellite System).
 
 - **IPv4 Client**:
   Demonstrates communication via TCP over IPv4 frames.

--- a/samples/common/common.mk
+++ b/samples/common/common.mk
@@ -44,6 +44,7 @@ EXE += \
 	xbee_ftp \
 	xbee_netcat \
 	xbee_term \
+	xbee3_ble_scanner \
 	xbee3_ota_tool \
 	xbee3_secure_session \
 	xbee3_srp_verifier \
@@ -154,6 +155,11 @@ xbee_ftp_OBJECTS = $(zigbee_OBJECTS) $(atinter_OBJECTS) \
             xbee_discovery.o xbee_file_system.o \
             _nodetable.o sample_cli.o xbee_ftp.o
 xbee_ftp : $(xbee_ftp_OBJECTS)
+	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
+
+xbee3_ble_scanner_OBJECTS = $(xbee_OBJECTS) xbee3_ble_scanner.o \
+            xbee_term_$(PORT).o xbee_ble.o
+xbee3_ble_scanner: $(xbee3_ble_scanner_OBJECTS)
 	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 xbee3_ota_tool_OBJECTS = $(zigbee_OBJECTS) $(atinter_OBJECTS) \

--- a/samples/common/common.mk
+++ b/samples/common/common.mk
@@ -31,6 +31,8 @@ EXE += \
 	commissioning_client \
 	commissioning_server \
 	eblinfo \
+	gnss_locate \
+	gnss_nmea \
 	gpm \
 	install_ebin \
 	install_ebl \
@@ -83,6 +85,14 @@ zigbee_OBJECTS = $(wpan_OBJECTS) zigbee_zcl.o zigbee_zdo.o zcl_types.o
 atinter_OBJECTS = xbee_readline.o _atinter.o
 
 atinter : $(xbee_OBJECTS) $(atinter_OBJECTS) atinter.o
+	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
+
+gnss_locate_OBJECTS = $(xbee_OBJECTS) gnss_locate.o $(atinter_OBJECTS) xbee_gnss.o
+gnss_locate : $(gnss_locate_OBJECTS)
+	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
+
+gnss_nmea_OBJECTS = $(xbee_OBJECTS) gnss_nmea.o $(atinter_OBJECTS) xbee_gnss.o
+gnss_nmea : $(gnss_nmea_OBJECTS)
 	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
 
 gpm : $(zigbee_OBJECTS) $(atinter_OBJECTS) xbee_gpm.o gpm.o

--- a/samples/common/gnss_locate.c
+++ b/samples/common/gnss_locate.c
@@ -44,21 +44,21 @@ xbee_dev_t my_xbee;
 int gnss_start_stop_handler( xbee_dev_t *xbee, const void FAR *raw,
     uint16_t length, void FAR *context);
 
-#define XBEE_FRAME_GNSS_START_STOP_HANDLE     \
+#define XBEE_FRAME_HANDLE_GNSS_START_STOP     \
     { XBEE_FRAME_GNSS_START_STOP_RESP, 0, gnss_start_stop_handler, NULL }
 
 int one_shot_handler( xbee_dev_t *xbee, const void FAR *raw,
     uint16_t length, void FAR *context);
 
-#define XBEE_FRAME_GNSS_ONE_SHOT_HANDLE \
+#define XBEE_FRAME_HANDLE_GNSS_ONE_SHOT \
     { XBEE_FRAME_GNSS_ONE_SHOT_RESP, 0, one_shot_handler, NULL }
 
 
 const xbee_dispatch_table_entry_t xbee_frame_handlers[] =
 {
     XBEE_FRAME_HANDLE_LOCAL_AT,
-    XBEE_FRAME_GNSS_START_STOP_HANDLE,
-    XBEE_FRAME_GNSS_ONE_SHOT_HANDLE,
+    XBEE_FRAME_HANDLE_GNSS_START_STOP,
+    XBEE_FRAME_HANDLE_GNSS_ONE_SHOT,
     XBEE_FRAME_TABLE_END
 };
 
@@ -69,10 +69,10 @@ int gnss_start_stop_handler(xbee_dev_t *xbee, const void FAR *raw,
 {
     const xbee_frame_gnss_start_stop_resp_t FAR *gnss = raw;
 
-    switch (gnss->type) {
-    case XBEE_GNSS_START_ONE_SHOT:
+    switch (gnss->request) {
+    case XBEE_GNSS_REQUEST_START_ONE_SHOT:
 
-    	if (gnss->status != GNSS_START_STOP_STATUS_SUCCESS) {
+    	if (gnss->status != XBEE_GNSS_START_STOP_STATUS_SUCCESS) {
     		printf("Got failure response for starting GNSS one shot\n");
     	} else {
     		printf("Got success response for starting GNSS one shot\n");
@@ -80,9 +80,9 @@ int gnss_start_stop_handler(xbee_dev_t *xbee, const void FAR *raw,
 
     	break;
 
-    case XBEE_GNSS_STOP_ONE_SHOT:
+    case XBEE_GNSS_REQUEST_STOP_ONE_SHOT:
 
-    	if (gnss->status != GNSS_START_STOP_STATUS_SUCCESS) {
+    	if (gnss->status != XBEE_GNSS_START_STOP_STATUS_SUCCESS) {
     		printf("Got failure response for stopping GNSS one shot\n");
     	} else {
     		printf("Got success response for stopping GNSS one shot\n");
@@ -91,7 +91,7 @@ int gnss_start_stop_handler(xbee_dev_t *xbee, const void FAR *raw,
     	break;
 
     default:
-    	printf("Unexpected gnss start stop response type %u\n", gnss->type);
+    	printf("Unexpected gnss start stop response type %u\n", gnss->request);
     }
 
     return 0;
@@ -114,10 +114,10 @@ int one_shot_handler(xbee_dev_t *xbee, const void FAR *raw,
         } latitude, longitude;
 
         printf("\nReceived one shot location:\n");
-        latitude.u =  be32toh(gnss->latitude);
-        longitude.u = be32toh(gnss->longitude);
-        printf("latitude %i.%06u  longitude %i.%06u\n", latitude.i / 10000000, abs(latitude.i % 10000000), longitude.i / 10000000, abs(longitude.i % 10000000));
-        unsigned int altitude = be32toh(gnss->altitude);
+        latitude.u =  be32toh(gnss->latitude_be);
+        longitude.u = be32toh(gnss->longitude_be);
+        printf("latitude %i.%06u  longitude %i.%06u\n", latitude.i / 10000000, abs(latitude.i) % 10000000, longitude.i / 10000000, abs(longitude.i) % 10000000);
+        unsigned int altitude = be32toh(gnss->altitude_be);
         printf("altitude %u.%03u meters\n", altitude / 1000, altitude % 1000);
         printf("satellites: %u\n", gnss->satellites);
         break;

--- a/samples/common/gnss_locate.c
+++ b/samples/common/gnss_locate.c
@@ -107,9 +107,10 @@ int one_shot_handler(xbee_dev_t *xbee, const void FAR *raw,
 
     switch (gnss->status) {
     case XBEE_GNSS_ONE_SHOT_STATUS_VALID:
+    {
         union {
             int32_t i;
-            int32_t u;
+            uint32_t u;
         } latitude, longitude;
 
         printf("\nReceived one shot location:\n");
@@ -120,6 +121,7 @@ int one_shot_handler(xbee_dev_t *xbee, const void FAR *raw,
         printf("altitude %u.%03u meters\n", altitude / 1000, altitude % 1000);
         printf("satellites: %u\n", gnss->satellites);
         break;
+    }
 
     case XBEE_GNSS_ONE_SHOT_STATUS_INVALID:
         printf("Received one shot status invalid\n");

--- a/samples/common/gnss_locate.c
+++ b/samples/common/gnss_locate.c
@@ -1,0 +1,238 @@
+/*
+ * Copyright (c) 2024 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 9350 Excelsior Blvd #700, Hopkins, MN 55343
+ * =======================================================================
+ */
+
+/*
+ * Sample program demonstrating finding the current location for XBee devices
+ * that support GNSS.
+ *
+ * Usage: ./gnss_locate [SERIAL...]
+ *
+ * The program will read lines from stdin, terminated by a platform-specific
+ * sequence, which will be stripped. For each line, if the line starts with the
+ * letters "AT", ignoring differences in case, then the line will be sent to the
+ * XBee as an AT command. Upon execution of the program, the program will
+ * issue a request to the device to get the location. The user may start a new
+ * request or stop the current request by typing 'start' or 'stop'.
+ * You may also type 'quit' to exit this program.
+ */
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "xbee/atcmd.h"
+#include "xbee/device.h"
+#include "xbee/byteorder.h"
+#include "xbee/gnss.h"
+
+// Common code
+#include "_atinter.h"
+#include "parse_serial_args.h"
+
+// An instance required for the local XBee
+xbee_dev_t my_xbee;
+
+
+int gnss_start_stop_handler( xbee_dev_t *xbee, const void FAR *raw,
+    uint16_t length, void FAR *context);
+
+#define XBEE_FRAME_GNSS_START_STOP_HANDLE     \
+    { XBEE_FRAME_GNSS_START_STOP_RESP, 0, gnss_start_stop_handler, NULL }
+
+int one_shot_handler( xbee_dev_t *xbee, const void FAR *raw,
+    uint16_t length, void FAR *context);
+
+#define XBEE_FRAME_GNSS_ONE_SHOT_HANDLE \
+    { XBEE_FRAME_GNSS_ONE_SHOT_RESP, 0, one_shot_handler, NULL }
+
+
+const xbee_dispatch_table_entry_t xbee_frame_handlers[] =
+{
+    XBEE_FRAME_HANDLE_LOCAL_AT,
+    XBEE_FRAME_GNSS_START_STOP_HANDLE,
+    XBEE_FRAME_GNSS_ONE_SHOT_HANDLE,
+    XBEE_FRAME_TABLE_END
+};
+
+
+// function that handles received GNSS start stop messages
+int gnss_start_stop_handler(xbee_dev_t *xbee, const void FAR *raw,
+    uint16_t length, void FAR *context)
+{
+    const xbee_frame_gnss_start_stop_resp_t FAR *gnss = raw;
+
+    switch (gnss->type) {
+    case XBEE_GNSS_START_ONE_SHOT:
+
+    	if (gnss->status != GNSS_START_STOP_STATUS_SUCCESS) {
+    		printf("Got failure response for starting GNSS one shot\n");
+    	} else {
+    		printf("Got success response for starting GNSS one shot\n");
+    	}
+
+    	break;
+
+    case XBEE_GNSS_STOP_ONE_SHOT:
+
+    	if (gnss->status != GNSS_START_STOP_STATUS_SUCCESS) {
+    		printf("Got failure response for stopping GNSS one shot\n");
+    	} else {
+    		printf("Got success response for stopping GNSS one shot\n");
+    	}
+
+    	break;
+
+    default:
+    	printf("Unexpected gnss start stop response type %u\n", gnss->type);
+    }
+
+    return 0;
+}
+
+
+// function that handles received one shot messages
+int one_shot_handler(xbee_dev_t *xbee, const void FAR *raw,
+    uint16_t length, void FAR *context)
+{
+    const xbee_frame_gnss_one_shot_resp_t FAR *gnss = raw;
+
+
+    switch (gnss->status) {
+    case XBEE_GNSS_ONE_SHOT_STATUS_VALID:
+        union {
+            int32_t i;
+            int32_t u;
+        } latitude, longitude;
+
+        printf("\nReceived one shot location:\n");
+        latitude.u =  be32toh(gnss->latitude);
+        longitude.u = be32toh(gnss->longitude);
+        printf("latitude %i.%06u  longitude %i.%06u\n", latitude.i / 10000000, abs(latitude.i % 10000000), longitude.i / 10000000, abs(longitude.i % 10000000));
+        unsigned int altitude = be32toh(gnss->altitude);
+        printf("altitude %u.%03u meters\n", altitude / 1000, altitude % 1000);
+        printf("satellites: %u\n", gnss->satellites);
+        break;
+
+    case XBEE_GNSS_ONE_SHOT_STATUS_INVALID:
+        printf("Received one shot status invalid\n");
+        break;
+
+    case XBEE_GNSS_ONE_SHOT_STATUS_TIMEOUT:
+        printf("Received one shot status timeout\n");
+        break;
+
+    case XBEE_GNSS_ONE_SHOT_STATUS_CANCELED:
+        printf("Received one shot status canceled\n");
+        break;
+
+    default:
+        printf("Received unexpected one shot status %d\n", gnss->status);
+
+        break;
+    }
+
+    return 0;
+}
+
+
+int main( int argc, char *argv[])
+{
+    char term_str[64];
+    int status;
+    xbee_serial_t xbee_ser;
+    int update_one_shot_state = 1;
+    int want_one_shot_active = 1;
+
+    parse_serial_arguments(argc, argv, &xbee_ser);
+
+    // Initialize the serial and device layer for this XBee device
+    if (xbee_dev_init(&my_xbee, &xbee_ser, NULL, NULL))
+    {
+        printf( "Failed to initialize device.\n");
+        return 0;
+    }
+
+    xbee_cmd_init_device(&my_xbee);
+    printf( "Waiting for driver to query the XBee device...\n");
+    do {
+        xbee_dev_tick(&my_xbee);
+        status = xbee_cmd_query_status(&my_xbee);
+    } while (status == -EBUSY);
+    if (status)
+    {
+        printf( "Error %d waiting for query to complete.\n", status);
+    }
+
+    // Report on the settings
+    xbee_dev_dump_settings(&my_xbee, XBEE_DEV_DUMP_FLAG_DEFAULT);
+
+    puts("This sample waits for a GNSS location and displays it");
+    puts("You may stop the location request by typing 'stop'");
+    puts("You may start a new location request by typing 'start'");
+    puts("You may issue AT commands by entering a command prefaced by AT");
+    puts("You may exit this program by typing 'quit'");
+    puts("");
+
+
+    while (1)
+    {
+
+        if (update_one_shot_state) {
+
+            update_one_shot_state = 0;
+
+            if (want_one_shot_active) {
+
+                status = xbee_gnss_start_one_shot(&my_xbee, 300, 0);
+                if (status < 0) {
+                    printf("Error %d starting one shot location request\n", status);
+                } else {
+                    printf("Starting one shot location request\n");
+                }
+
+            } else {
+                status = xbee_gnss_stop_one_shot(&my_xbee, 0);
+                if (status < 0) {
+                    printf("Error %d stopping one shot location request\n", status);
+                } else {
+                    printf("Stopping one shot location request\n");
+                }
+            }
+        }
+
+        while ((status = xbee_readline(term_str, sizeof term_str)) == -EAGAIN) {
+            status = xbee_dev_tick(&my_xbee);
+            if (status < 0) {
+               printf("Error %d from xbee_dev_tick().\n", status);
+               return -1;
+            }
+            xbee_cmd_tick();
+        }
+        if (status == -ENODATA || ! strcmpi(term_str, "quit")){
+            return 0;
+        }
+        else if (! strncmpi(term_str, "AT", 2)) {
+            process_command(&my_xbee, term_str);
+        }
+        else if (term_str[0] == 0) {
+            puts("");
+        }
+        else if (! strcmpi(term_str, "stop")) {
+            update_one_shot_state = 1;
+            want_one_shot_active = 0;
+        }
+        else if (! strcmpi(term_str, "start")) {
+            update_one_shot_state = 1;
+            want_one_shot_active = 1;
+        }
+
+    }
+}

--- a/samples/common/gnss_nmea.c
+++ b/samples/common/gnss_nmea.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2024 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 9350 Excelsior Blvd #700, Hopkins, MN 55343
+ * =======================================================================
+ */
+
+/*
+ * Sample program demonstrating streaming of NMEA for XBee devices that support
+ * GNSS.
+ *
+ * Usage: ./gnss_nmea [SERIAL...]
+ *
+ * The program will read lines from stdin, terminated by a platform-specific
+ * sequence, which will be stripped. For each line, if the line starts with the
+ * letters "AT", ignoring differences in case, then the line will be sent to the
+ * XBee as an AT command. Upon execution of the program, the program will
+ * issue a request to the device to begin streaming NMEA. The user may start
+ * and stop the NMEA stream by typing 'start' or 'stop'.
+ * You may also type 'quit' to exit this program.
+ */
+#include <stdio.h>
+#include <string.h>
+
+#include "xbee/atcmd.h"
+#include "xbee/device.h"
+#include "xbee/gnss.h"
+
+// Common code
+#include "_atinter.h"
+#include "parse_serial_args.h"
+
+// An instance required for the local XBee
+xbee_dev_t my_xbee;
+
+
+int gnss_start_stop_handler( xbee_dev_t *xbee, const void FAR *raw,
+    uint16_t length, void FAR *context);
+
+#define XBEE_FRAME_GNSS_START_STOP_HANDLE     \
+    { XBEE_FRAME_GNSS_START_STOP_RESP, 0, gnss_start_stop_handler, NULL }
+
+int nmea_handler( xbee_dev_t *xbee, const void FAR *raw,
+    uint16_t length, void FAR *context);
+
+#define XBEE_FRAME_GNSS_NMEA_HANDLE     \
+    { XBEE_FRAME_GNSS_RAW_NMEA_RESP, 0, nmea_handler, NULL }
+
+
+const xbee_dispatch_table_entry_t xbee_frame_handlers[] =
+{
+    XBEE_FRAME_HANDLE_LOCAL_AT,
+    XBEE_FRAME_GNSS_START_STOP_HANDLE,
+    XBEE_FRAME_GNSS_NMEA_HANDLE,
+    XBEE_FRAME_TABLE_END
+};
+
+
+// function that handles received GNSS start stop messages
+int gnss_start_stop_handler(xbee_dev_t *xbee, const void FAR *raw,
+    uint16_t length, void FAR *context)
+{
+    const xbee_frame_gnss_start_stop_resp_t FAR *gnss = raw;
+
+    switch (gnss->type) {
+    case XBEE_GNSS_START_RAW_NMEA:
+
+        if (gnss->status != GNSS_START_STOP_STATUS_SUCCESS) {
+            printf("Got failure response for starting GNSS NMEA\n");
+        } else {
+            printf("Got success response for starting GNSS NMEA\n");
+        }
+
+
+        break;
+
+    case XBEE_GNSS_STOP_RAW_NMEA:
+
+        if (gnss->status != GNSS_START_STOP_STATUS_SUCCESS) {
+            printf("Got failure response for stopping GNSS NMEA\n");
+        } else {
+            printf("Got success response for stopping GNSS NMEA\n");
+        }
+
+        break;
+
+    default:
+        printf("Unexpected gnss start stop response type %u\n", gnss->type);
+    }
+
+    return 0;
+}
+
+
+// function that handles received NMEA messages
+int nmea_handler(xbee_dev_t *xbee, const void FAR *raw,
+    uint16_t length, void FAR *context)
+{
+	char nmea_str[1600];
+    const xbee_frame_gnss_raw_nmea_resp_t FAR *gnss = raw;
+
+    int16_t payload_len = length - offsetof(xbee_frame_gnss_raw_nmea_resp_t, payload);
+
+    if (payload_len >= sizeof(nmea_str)) {
+    	printf("PAYLOAD TOO BIG: %lu bytes dropped\n", (payload_len - sizeof(nmea_str) + 1));
+    	payload_len = sizeof(nmea_str) - 1;
+    }
+
+    memcpy(nmea_str, &gnss->payload[0], payload_len);
+    nmea_str[payload_len] = '\0';
+
+    printf("%s\n", nmea_str);
+    return 0;
+}
+
+int main( int argc, char *argv[])
+{
+    // Enough to get a useful error when the message is too long:
+    char term_str[64];
+    int status;
+    xbee_serial_t xbee_ser;
+    int update_nmea_state = 1;
+    int want_nmea_active = 1;
+
+    parse_serial_arguments(argc, argv, &xbee_ser);
+
+    // Initialize the serial and device layer for this XBee device
+    if (xbee_dev_init(&my_xbee, &xbee_ser, NULL, NULL))
+    {
+        printf( "Failed to initialize device.\n");
+        return 0;
+    }
+
+    xbee_cmd_init_device(&my_xbee);
+    printf( "Waiting for driver to query the XBee device...\n");
+    do {
+        xbee_dev_tick(&my_xbee);
+        status = xbee_cmd_query_status(&my_xbee);
+    } while (status == -EBUSY);
+    if (status)
+    {
+        printf( "Error %d waiting for query to complete.\n", status);
+    }
+
+    // Report on the settings
+    xbee_dev_dump_settings(&my_xbee, XBEE_DEV_DUMP_FLAG_DEFAULT);
+
+    puts("This sample displays GNSS NMEA stream");
+    puts("You may stop the stream by typing 'stop'");
+    puts("You may start the stream again by typing 'start'");
+    puts("You may issue AT commands by entering a command prefaced by AT");
+    puts("You may exit this program by typing 'quit'");
+    puts("");
+
+    while (1)
+    {
+
+        if (update_nmea_state) {
+
+            update_nmea_state = 0;
+
+            if (want_nmea_active) {
+
+            	status = xbee_gnss_start_raw_nmea(&my_xbee, 0);
+            	if (status < 0) {
+            		printf("Error %d starting GNSS raw NMEA stream\n", status);
+            	} else {
+                    printf("Starting GNSS raw NMEA stream\n");
+                }
+
+            } else {
+                status = xbee_gnss_stop_raw_nmea(&my_xbee, 0);
+                if (status < 0) {
+                    printf("Error %d stopping GNSS raw NMEA stream\n", status);
+                } else {
+                    printf("Stopping GNSS raw NMEA stream\n");
+                }
+            }
+        }
+
+        while ((status = xbee_readline(term_str, sizeof term_str)) == -EAGAIN) {
+            status = xbee_dev_tick(&my_xbee);
+            if (status < 0) {
+               printf("Error %d from xbee_dev_tick().\n", status);
+               return -1;
+            }
+            xbee_cmd_tick();
+        }
+        if (status == -ENODATA || ! strcmpi(term_str, "quit")){
+            return 0;
+        }
+        else if (! strncmpi(term_str, "AT", 2)) {
+            process_command(&my_xbee, term_str);
+        }
+        else if (term_str[0] == 0) {
+            puts("");
+        }
+        else if (! strcmpi(term_str, "stop")) {
+            update_nmea_state = 1;
+            want_nmea_active = 0;
+        }
+        else if (! strcmpi(term_str, "start")) {
+            update_nmea_state = 1;
+            want_nmea_active = 1;
+        }
+    }
+    return 0;
+}

--- a/samples/common/xbee3_ble_scanner.c
+++ b/samples/common/xbee3_ble_scanner.c
@@ -10,6 +10,13 @@
  * ===========================================================================
  */
 
+/*
+    Sample: XBee 3 BLE Scanner
+
+    Tool used for manually performing BLE GAP scans to explore the
+    xbee/xbee_ble.c APIs.  For use with XBee 3 BLU.
+*/
+
 #include <stdio.h>
 #include <limits.h>
 #include <string.h>
@@ -98,7 +105,7 @@ int ble_scanner_sample(xbee_dev_t *xbee, uint16_t scan_duration,
             fprintf(stderr, "Initiating scan\n");
             result = xbee_ble_scan_start(xbee, scan_duration, scan_window,
                         scan_interval, filter_type,
-                        (const uint8_t *)filter_local_name, filter_len);
+                        filter_local_name, filter_len);
             if (result < 0) {
                 fprintf(stderr, "scan start failed with %d\n", result);
                 return EXIT_FAILURE;

--- a/samples/common/xbee3_ble_scanner.c
+++ b/samples/common/xbee3_ble_scanner.c
@@ -1,0 +1,293 @@
+/*
+ * Copyright (c) 2019 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc., 9350 Excelsior Blvd., Suite 700, Hopkins, MN 55343
+ * ===========================================================================
+ */
+
+#include <stdio.h>
+#include <limits.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "xbee/platform.h"
+#include "xbee/device.h"
+#include "xbee/ble.h"
+
+#include "_xbee_term.h"  
+
+
+typedef enum ble_scan_state_e {
+    SCAN_STATE_INIT,
+    SCAN_STATE_AWAIT_START,
+    SCAN_STATE_RUNNING,
+    SCAN_STATE_STOPPED,
+    SCAN_STATE_ERROR,
+} ble_scan_state_t;
+
+static ble_scan_state_t scan_state;
+
+#define XBEE_BLE_FRAME_HANDLERS \
+    { XBEE_FRAME_BLE_SCAN_STATUS, 0, scan_status_handler, NULL}, \
+    { XBEE_FRAME_BLE_SCAN_LEGACY_ADVERT_RESP, 0, xbee_ble_scan_legacy_advert_dump, NULL}, \
+    { XBEE_FRAME_BLE_SCAN_EXT_ADVERT_RESP, 0, xbee_ble_scan_ext_advert_dump, NULL}
+
+#define BLE_SCAN_INTERVAL_DEFAULT_USEC (0x138800) // 1.28 seconds
+#define BLE_SCAN_WINDOW_DEFAULT_USEC   (0x2BF2)   // 11.25 milliseconds
+
+static int scan_status_handler(xbee_dev_t *xbee, const void FAR *raw,
+                               uint16_t length, void FAR *context)
+{
+    const xbee_frame_ble_scan_status_t FAR *status = raw;
+
+    switch (status->scan_status) {
+    case XBEE_BLE_SCAN_STATUS_SUCCESS:
+        /* Intentional fall-through */
+    case XBEE_BLE_SCAN_STATUS_RUNNING:
+        scan_state = SCAN_STATE_RUNNING;
+        fprintf(stderr, "Scan is running\n\n");
+        break;
+
+    case XBEE_BLE_SCAN_STATUS_STOPPED:
+        scan_state = SCAN_STATE_STOPPED;
+        fprintf(stderr, "Scan has stopped\n");
+        break;
+
+    case XBEE_BLE_SCAN_STATUS_ERROR:
+        fprintf(stderr, "The scan failed to start\n");
+        scan_state = SCAN_STATE_ERROR;
+        break;
+    case XBEE_BLE_SCAN_STATUS_INVALID_PARAMS:
+        fprintf(stderr, "The scan failed to start due to invalid parameters\n");
+        scan_state = SCAN_STATE_ERROR;
+        break;
+    default:
+        fprintf(stderr, "An unknown error occoured: %" PRIu8"\n",
+                status->scan_status);
+        scan_state = SCAN_STATE_ERROR;
+        break;
+   };
+
+    return 0;
+}
+
+int ble_scanner_sample(xbee_dev_t *xbee, uint16_t scan_duration,
+                       uint32_t scan_window, uint32_t scan_interval,
+                       const char *filter_local_name)
+{
+    int result;
+    const uint8_t filter_type = filter_local_name ? XBEE_BLE_SCAN_FILTER_NAME : 0;
+    const size_t filter_len = filter_local_name ? strlen(filter_local_name) : 0;
+    scan_state = SCAN_STATE_INIT;
+
+    while (scan_state < SCAN_STATE_STOPPED) {
+        result = xbee_dev_tick(xbee);
+        if (result < 0) {
+            fprintf(stderr, "xbee_dev_tick failed with %d\n", result);
+            return EXIT_FAILURE;
+        }
+
+        if (scan_state == SCAN_STATE_INIT) {
+            // Send scan initiation
+            fprintf(stderr, "Initiating scan\n");
+            result = xbee_ble_scan_start(xbee, scan_duration, scan_window,
+                        scan_interval, filter_type,
+                        (const uint8_t *)filter_local_name, filter_len);
+            if (result < 0) {
+                fprintf(stderr, "scan start failed with %d\n", result);
+                return EXIT_FAILURE;
+            }
+            fprintf(stderr, "Scan started with result %d\n", result);
+            scan_state = SCAN_STATE_AWAIT_START;
+        }
+    }
+
+    if (scan_state == SCAN_STATE_ERROR) {
+        printf("There was a failure during the scan\n");
+        result = EXIT_FAILURE;
+    }
+
+    return result;
+}
+
+
+void print_help(void)
+{
+    puts("XBee BLE Scanner");
+    puts("Usage: xbee3_ble_scan [options] [duration]");
+    puts("");
+    puts("  -b baudrate           Baudrate for XBee interface (default 115200)");
+    puts("  -x serialport         Serial port for XBee interface");
+    puts("                        ('COMxx' for Win32, '/dev/ttySxx' for POSIX)");
+    puts("  -f filter_name        Local name to filter advertisements by");
+    puts("  -i scan_interval      The scan interval in microseconds");
+    puts("  -w scan_window        The scan window in microseconds");
+    puts("  -h                    Display this help screen");
+    puts("");
+}
+
+// returns ULONG_MAX if unable to completely parse <str> or <str> is empty
+unsigned long parse_num(const char *str)
+{
+    char *endptr;
+    unsigned long parsed_num;
+
+    if (!str || *str == '\0') {
+        return ULONG_MAX;
+    }
+    parsed_num = strtoul(str, &endptr, 0);
+
+    return *endptr != '\0' ? ULONG_MAX : parsed_num;
+}
+
+int main(int argc, char *argv[])
+{
+    xbee_dev_t xbee_dev;
+    int c;
+    unsigned long param;
+    char *filter_name = NULL;
+    uint32_t scan_window = BLE_SCAN_WINDOW_DEFAULT_USEC;
+    uint32_t scan_interval = BLE_SCAN_INTERVAL_DEFAULT_USEC;
+    uint16_t scan_duration = 0;
+
+    // parsed command-line options with default values
+    xbee_serial_t xbee_serial = { .baudrate = 115200 };
+    int parse_error = 0;
+
+    while ( (c = getopt(argc, argv, "b:hf:x:i:w:")) != -1) {
+        switch (c) {
+        case 'b': {
+            unsigned long param = parse_num(optarg);
+            if (param > 0 && param <= 1000000) {
+                xbee_serial.baudrate = (uint32_t)param;
+            } else {
+                fprintf(stderr, "ERROR: failed to parse baudrate '%s'\n",
+                        optarg);
+                ++parse_error;
+            }
+            break;
+        }
+
+        case '?':
+            ++parse_error;
+            // fall through to printing help
+        case 'h':
+            print_help();
+            break;
+
+        case 'x':
+#ifdef POSIX
+            snprintf(xbee_serial.device, sizeof xbee_serial.device,
+                    "%s", optarg);
+#else // assume Win32
+            if (memcmp(optarg, "COM", 3) == 0) {
+                unsigned long param = parse_num(&optarg[3]);
+                if (param > 0 && param < 256) {
+                    xbee_serial.comport = (int)param;
+                    break;
+                }
+           
+            }
+            fprintf(stderr,
+                    "ERROR: expected 'COM<n>' (1 to 255) for serial port\n");
+            ++parse_error;
+#endif
+            break;
+        case 'f':
+            filter_name = optarg;
+            break;
+
+        case 'i':
+            param = parse_num(optarg);
+            if (param >= XBEE_BLE_SCAN_VALUES_MIN_USEC && 
+                param <= XBEE_BLE_SCAN_VALUES_MAX_USEC) {
+                scan_interval = (uint32_t)param;
+            } else {
+                fprintf(stderr, "ERROR: failed to parse scan interval '%s'\n",
+                        optarg);
+                ++parse_error;
+            }
+            break;
+
+        case 'w':
+            param = parse_num(optarg);
+            if (param >= XBEE_BLE_SCAN_VALUES_MIN_USEC && 
+                param <= XBEE_BLE_SCAN_VALUES_MAX_USEC) {
+                scan_window = (uint32_t)param;
+            } else {
+                fprintf(stderr, "ERROR: failed to parse scan window '%s'\n",
+                        optarg);
+                ++parse_error;
+            }
+            break;
+
+        default:
+            fprintf(stderr, "ERROR: unknown option '%c'\n", c);
+            ++parse_error;
+        }
+    }
+
+    if (optind + 1 > argc) {
+        fprintf(stderr, "ERROR: insufficient arguments\n");
+        ++parse_error;
+    } else {
+        param = parse_num(argv[optind]);
+
+        if (param >= 0 && param <= UINT16_MAX) {
+            scan_duration = (uint16_t) param;
+        } else {
+            fprintf(stderr,
+                    "ERROR: failed to parse scan duration '%s'\n",
+                    argv[optind]);
+            ++parse_error;
+        }
+        ++optind;
+    }
+
+    if (!parse_error && optind != argc) {
+        fprintf(stderr, "ERROR: %u unexpected argument(s)\n", argc - optind);
+        ++parse_error;
+    }
+
+    if (parse_error) {
+       return EXIT_FAILURE;
+    }
+
+#ifdef POSIX
+    fprintf(stderr, "Opening %s at %u baud...\n",
+            xbee_serial.device, xbee_serial.baudrate);
+#else
+    fprintf(stderr, "Opening COM%u at %u baud...\n",
+            xbee_serial.comport, xbee_serial.baudrate);
+#endif
+
+    if (xbee_dev_init(&xbee_dev, &xbee_serial, NULL, NULL)) {
+        fprintf(stderr, "ERROR: Failed to initialize serial connection.\n");
+        return EXIT_FAILURE;
+    }
+
+    xbee_term_console_init();
+    xbee_term_set_color(SOURCE_STATUS);
+
+    int result = ble_scanner_sample(&xbee_dev, scan_duration, scan_window,
+                                    scan_interval,  filter_name);
+
+    xbee_term_console_restore();
+
+    fprintf(stderr, "Closing serial port...\n");
+    xbee_ser_close(&xbee_serial);
+
+    return result;
+}
+
+const xbee_dispatch_table_entry_t xbee_frame_handlers[] = {
+    XBEE_BLE_FRAME_HANDLERS,
+    XBEE_FRAME_TABLE_END
+};
+

--- a/src/xbee/xbee_ble.c
+++ b/src/xbee/xbee_ble.c
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) 2024 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc., 9350 Excelsior Blvd., Suite 700, Hopkins, MN 55343
+ * ===========================================================================
+ */
+
+/**
+    @addtogroup xbee_ble
+    @{
+    @file xbee_ble.c
+
+    See xbee/ble.h for summary of API.
+*/
+
+#include <stdio.h>
+#include <string.h>
+
+#include "xbee/device.h"
+#include "xbee/platform.h"
+#include "xbee/ble.h"
+
+
+int xbee_ble_scan_start(xbee_dev_t *xbee, uint16_t scan_duration,
+                        uint32_t scan_window, uint32_t scan_interval,
+                        uint8_t filter_type,  const uint8_t *filter,
+                        size_t filter_len)
+{
+    if (!xbee || (!filter && filter_len)) {
+        return -EINVAL;
+    }
+
+    // Bounds check scan window and interval
+    if (scan_window > scan_interval) {
+        return -EINVAL;
+    }
+
+    // Bounds check filter
+    switch (filter_type) {
+    case XBEE_BLE_SCAN_FILTER_NAME:
+        if (filter_len > 22) {
+            return -E2BIG;
+        }
+        break;
+
+    default:
+        // No filter
+        break;
+    };
+
+    xbee_header_ble_scan_req_t header;
+
+    header.frame_type = XBEE_FRAME_BLE_SCAN_REQUEST;
+    header.start_cmd = 1;
+    header.scan_duration_be = htobe16(scan_duration);
+    header.scan_window_be = htobe32(scan_window);
+    header.scan_interval_be = htobe32(scan_interval);
+    header.filter_type = filter_type;
+
+    return  xbee_frame_write(xbee, &header, sizeof(header),
+                             filter, filter_len, 0);
+}
+
+int xbee_ble_scan_stop(xbee_dev_t *xbee)
+{
+    if (!xbee) {
+        return -EINVAL;
+    }
+    xbee_header_ble_scan_req_t header;
+
+    // Clear other unused fields
+    memset(&header, 0, sizeof(header));
+
+    header.frame_type = XBEE_FRAME_BLE_SCAN_REQUEST;
+    header.start_cmd = 0;
+
+    return xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
+}
+
+static const char *xbee_ble_scan_status_str(uint8_t status)
+{
+    switch( status ) {
+    case XBEE_BLE_SCAN_STATUS_SUCCESS:           return "started";
+    case XBEE_BLE_SCAN_STATUS_RUNNING:           return "running";
+    case XBEE_BLE_SCAN_STATUS_STOPPED:           return "stopped";
+    case XBEE_BLE_SCAN_STATUS_ERROR:             return "error";
+    case XBEE_BLE_SCAN_STATUS_INVALID_PARAMS:    return "invalid parameters";
+    default:                                     return "unknown";
+    };
+}
+
+int xbee_ble_scan_status_dump(xbee_dev_t *xbee, const void FAR *raw,
+                              uint16_t length, void FAR *context)
+{
+    const xbee_frame_ble_scan_status_t FAR *status = raw;
+    const char *status_str = xbee_ble_scan_status_str(status->scan_status);
+
+    printf("BLE scan status: %s\n", status_str);
+    return 0;
+}
+
+#define BLE_MAC_ADDR_LENGTH 19
+static int xbee_ble_scan_mac_str(char *buf, const uint8_t mac[6])
+{
+    return sprintf(buf, "%02X:%02X:%02X:%02X:%02X:%02X",
+                   mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
+}
+
+int xbee_ble_scan_legacy_advert_dump(xbee_dev_t *xbee, const void FAR *raw,
+                                     uint16_t length, void FAR *context)
+{
+    const xbee_frame_ble_scan_legacy_advert_resp_t FAR *advert = raw;
+    char mac_addr_buf[BLE_MAC_ADDR_LENGTH];
+
+    xbee_ble_scan_mac_str(mac_addr_buf, advert->address);
+    bool_t connectable = advert->advert_flags & XBEE_BLE_ADVERT_FLAG_CONNECTABLE;
+
+    printf("Legacy advertisement from: %s\n RSSI: %d, Connectable: %s\n",
+           mac_addr_buf, -advert->rssi, connectable ? "true" : "false");
+    hex_dump(advert->payload, advert->payload_len, HEX_DUMP_FLAG_TAB);
+
+   return 0;
+}
+
+int xbee_ble_scan_ext_advert_dump(xbee_dev_t *xbee, const void FAR *raw,
+                                  uint16_t length, void FAR *context)
+{
+    const xbee_frame_ble_scan_ext_advert_resp_t FAR *advert = raw;
+    char mac_addr_buf[BLE_MAC_ADDR_LENGTH];
+
+    xbee_ble_scan_mac_str(mac_addr_buf, advert->address);
+    bool_t connectable = advert->advert_flags & XBEE_BLE_ADVERT_FLAG_CONNECTABLE;
+
+    printf("Extended advertisement from: %s\n RSSI: %d, Connectable: %s\n",
+           mac_addr_buf, -advert->rssi, connectable ? "true" : "false");
+    hex_dump(advert->payload, advert->payload_len, HEX_DUMP_FLAG_TAB);
+
+    return 0;
+}
+

--- a/src/xbee/xbee_ble.c
+++ b/src/xbee/xbee_ble.c
@@ -28,7 +28,7 @@
 
 int xbee_ble_scan_start(xbee_dev_t *xbee, uint16_t scan_duration,
                         uint32_t scan_window, uint32_t scan_interval,
-                        uint8_t filter_type,  const uint8_t *filter,
+                        uint8_t filter_type,  const void *filter,
                         size_t filter_len)
 {
     if (!xbee || (!filter && filter_len)) {
@@ -120,7 +120,7 @@ int xbee_ble_scan_legacy_advert_dump(xbee_dev_t *xbee, const void FAR *raw,
     xbee_ble_scan_mac_str(mac_addr_buf, advert->address);
     bool_t connectable = advert->advert_flags & XBEE_BLE_ADVERT_FLAG_CONNECTABLE;
 
-    printf("Legacy advertisement from: %s\n RSSI: %d, Connectable: %s\n",
+    printf("Legacy advertisement from: %s\n RSSI: %d dBm, Connectable: %s\n",
            mac_addr_buf, -advert->rssi, connectable ? "true" : "false");
     hex_dump(advert->payload, advert->payload_len, HEX_DUMP_FLAG_TAB);
 

--- a/src/xbee/xbee_gnss.c
+++ b/src/xbee/xbee_gnss.c
@@ -29,25 +29,20 @@ int xbee_gnss_start_one_shot(xbee_dev_t *xbee, uint16_t timeout, uint16_t option
         return -EINVAL;
     }
 
-    int retval;
-
     xbee_frame_gnss_start_stop_t header;
     
 
 	memset(&header, 0, sizeof(header));
-    header.type = XBEE_GNSS_START_ONE_SHOT;
-    header.timeout = htobe16(timeout);
+    header.request = XBEE_GNSS_REQUEST_START_ONE_SHOT;
+    header.timeout_be = htobe16(timeout);
     header.frame_type = XBEE_FRAME_GNSS_START_STOP;
 
 
-    if (options & XBEE_GNSS_START_STOP_OPT_NO_RESP) {
-        header.frame_id = 0;
-    } else {
+    if (!(options & XBEE_GNSS_START_STOP_OPT_NO_RESP)) {
         header.frame_id = xbee_next_frame_id(xbee);
     }
 
-    retval = xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
-    return retval;
+    return xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
 }
 
 // API documented in xbee/gnss.h
@@ -57,12 +52,10 @@ int xbee_gnss_stop_one_shot(xbee_dev_t *xbee, uint16_t options)
         return -EINVAL;
     }
 
-    int retval;
-
     xbee_frame_gnss_start_stop_t header;
     
     memset(&header, 0, sizeof(header));
-    header.type = XBEE_GNSS_STOP_ONE_SHOT;
+    header.request = XBEE_GNSS_REQUEST_STOP_ONE_SHOT;
     header.frame_type = XBEE_FRAME_GNSS_START_STOP;
 
 
@@ -72,8 +65,7 @@ int xbee_gnss_stop_one_shot(xbee_dev_t *xbee, uint16_t options)
         header.frame_id = xbee_next_frame_id(xbee);
     }
 
-    retval = xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
-    return retval;
+    return xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
 }
 
 // API documented in xbee/gnss.h
@@ -83,13 +75,11 @@ int xbee_gnss_start_raw_nmea(xbee_dev_t *xbee, uint16_t options)
         return -EINVAL;
     }
 
-    int retval;
-
     xbee_frame_gnss_start_stop_t header;
     
 
 	memset(&header, 0, sizeof(header));
-    header.type = XBEE_GNSS_START_RAW_NMEA;
+    header.request = XBEE_GNSS_REQUEST_START_RAW_NMEA;
     header.frame_type = XBEE_FRAME_GNSS_START_STOP;
 
 
@@ -99,8 +89,7 @@ int xbee_gnss_start_raw_nmea(xbee_dev_t *xbee, uint16_t options)
         header.frame_id = xbee_next_frame_id(xbee);
     }
 
-    retval = xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
-    return retval;
+    return xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
 }
 
 // API documented in xbee/gnss.h
@@ -110,12 +99,10 @@ int xbee_gnss_stop_raw_nmea(xbee_dev_t *xbee, uint16_t options)
         return -EINVAL;
     }
 
-    int retval;
-
     xbee_frame_gnss_start_stop_t header;
     
     memset(&header, 0, sizeof(header));
-    header.type = XBEE_GNSS_STOP_RAW_NMEA;
+    header.request = XBEE_GNSS_REQUEST_STOP_RAW_NMEA;
     header.frame_type = XBEE_FRAME_GNSS_START_STOP;
 
 
@@ -125,6 +112,5 @@ int xbee_gnss_stop_raw_nmea(xbee_dev_t *xbee, uint16_t options)
         header.frame_id = xbee_next_frame_id(xbee);
     }
 
-    retval = xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
-    return retval;
+    return xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
 }

--- a/src/xbee/xbee_gnss.c
+++ b/src/xbee/xbee_gnss.c
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2024 Digi International Inc.,
+ * All rights not expressly granted are reserved.
+ *
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this file,
+ * You can obtain one at http://mozilla.org/MPL/2.0/.
+ *
+ * Digi International Inc. 9350 Excelsior Blvd #700, Hopkins, MN 55343
+ * =======================================================================
+ */
+
+/**
+    @addtogroup xbee_gnss
+    @{
+    @file
+*/
+
+#include <stdio.h>
+#include <string.h>
+#include "xbee/platform.h"
+#include "xbee/gnss.h"
+#include "xbee/byteorder.h"
+
+// API documented in xbee/gnss.h
+int xbee_gnss_start_one_shot(xbee_dev_t *xbee, uint16_t timeout, uint16_t options)
+{
+    if (!xbee) {
+        return -EINVAL;
+    }
+
+    int retval;
+
+    xbee_frame_gnss_start_stop_t header;
+    
+
+	memset(&header, 0, sizeof(header));
+    header.type = XBEE_GNSS_START_ONE_SHOT;
+    header.timeout = htobe16(timeout);
+    header.frame_type = XBEE_FRAME_GNSS_START_STOP;
+
+
+    if (options & XBEE_GNSS_START_STOP_OPT_NO_RESP) {
+        header.frame_id = 0;
+    } else {
+        header.frame_id = xbee_next_frame_id(xbee);
+    }
+
+    retval = xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
+    return retval;
+}
+
+// API documented in xbee/gnss.h
+int xbee_gnss_stop_one_shot(xbee_dev_t *xbee, uint16_t options)
+{
+    if (!xbee) {
+        return -EINVAL;
+    }
+
+    int retval;
+
+    xbee_frame_gnss_start_stop_t header;
+    
+    memset(&header, 0, sizeof(header));
+    header.type = XBEE_GNSS_STOP_ONE_SHOT;
+    header.frame_type = XBEE_FRAME_GNSS_START_STOP;
+
+
+    if (options & XBEE_GNSS_START_STOP_OPT_NO_RESP) {
+        header.frame_id = 0;
+    } else {
+        header.frame_id = xbee_next_frame_id(xbee);
+    }
+
+    retval = xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
+    return retval;
+}
+
+// API documented in xbee/gnss.h
+int xbee_gnss_start_raw_nmea(xbee_dev_t *xbee, uint16_t options)
+{
+    if (!xbee) {
+        return -EINVAL;
+    }
+
+    int retval;
+
+    xbee_frame_gnss_start_stop_t header;
+    
+
+	memset(&header, 0, sizeof(header));
+    header.type = XBEE_GNSS_START_RAW_NMEA;
+    header.frame_type = XBEE_FRAME_GNSS_START_STOP;
+
+
+    if (options & XBEE_GNSS_START_STOP_OPT_NO_RESP) {
+        header.frame_id = 0;
+    } else {
+        header.frame_id = xbee_next_frame_id(xbee);
+    }
+
+    retval = xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
+    return retval;
+}
+
+// API documented in xbee/gnss.h
+int xbee_gnss_stop_raw_nmea(xbee_dev_t *xbee, uint16_t options)
+{
+    if (!xbee) {
+        return -EINVAL;
+    }
+
+    int retval;
+
+    xbee_frame_gnss_start_stop_t header;
+    
+    memset(&header, 0, sizeof(header));
+    header.type = XBEE_GNSS_STOP_RAW_NMEA;
+    header.frame_type = XBEE_FRAME_GNSS_START_STOP;
+
+
+    if (options & XBEE_GNSS_START_STOP_OPT_NO_RESP) {
+        header.frame_id = 0;
+    } else {
+        header.frame_id = xbee_next_frame_id(xbee);
+    }
+
+    retval = xbee_frame_write( xbee, &header, sizeof(header), NULL, 0, 0);
+    return retval;
+}

--- a/src/xbee/xbee_scan.c
+++ b/src/xbee/xbee_scan.c
@@ -18,6 +18,7 @@
 */
 
 #include <stdio.h>
+#include <ctype.h>
 
 #include "xbee/platform.h"
 #include "xbee/atcmd.h"
@@ -46,6 +47,23 @@ int xbee_scan_dump_response( xbee_dev_t *xbee, const void FAR *raw,
          if (scan_length < 1)
          {
             puts( "Scan complete");
+         }
+         else if ((xbee->hardware_series & XBEE_HW_SERIES_MASK) == XBEE_HW_SERIES_CELLULAR)
+         {
+            // Response is ASCII text, with \r for line endings.
+            // Print out the response as-is, but substitute \n line endings.
+            uint16_t i = 0;
+            uint8_t c;
+            for (i = 0; i < scan_length; i++)
+            {
+               uint8_t c = resp->value[i];
+               if (!isprint(c) && !isspace(c))
+               {
+                  printf( "Unexpected nonprintable byte in Cellular AS response: index %u, ASCII 0x%02X\n", i, c);
+                  return 0;
+               }
+               putchar(c == '\r' ? '\n' : c);
+            }
          }
          else switch (atas->as_type)
          {


### PR DESCRIPTION
* Define HV values for newer XBee 3 Cellular models and XBee 3 BLU
* Implement support for GNSS request frames
* Define HV values for XR, XBee RR TH, and XBee LR
* Implement cellular AS support for `xbee_scan_dump_response()`